### PR TITLE
Add load_normals_sample method to PolyMeshSchema for optional normals…

### DIFF
--- a/src/schemas/polymesh_schema.rs
+++ b/src/schemas/polymesh_schema.rs
@@ -112,6 +112,25 @@ impl PolyMeshSchema {
         Ok(chunk_vector_by_3(pod_array)?)
     }
 
+    pub fn load_normals_sample(
+        &self,
+        sample_index: u32,
+        reader: &mut dyn ArchiveReader,
+    ) -> Result<Vec<[f32; 3]>> {
+        if let Some(normals) = &self.normals {
+            let pod_array = normals.load_sample(sample_index, reader)?;
+            let pod_array = if let PodArray::F32(array) = pod_array {
+                array
+            } else {
+                return Err(InternalError::Unreachable.into());
+            };
+
+            Ok(chunk_vector_by_3(pod_array)?)
+        } else {
+            Ok(vec![])
+        }
+    }
+
     pub fn load_facecounts_sample(
         &self,
         sample_index: u32,


### PR DESCRIPTION
### **User description**
… loading


___

### **PR Type**
Enhancement


___

### **Description**
- Added `load_normals_sample` method to `PolyMeshSchema`.

- Enables optional loading of normals data.

- Handles cases where normals data is unavailable.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>polymesh_schema.rs</strong><dd><code>Added `load_normals_sample` method to `PolyMeshSchema`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/schemas/polymesh_schema.rs

<li>Introduced <code>load_normals_sample</code> method in <code>PolyMeshSchema</code>.<br> <li> Allows loading normals data for a given sample index.<br> <li> Returns empty vector if normals data is unavailable.<br> <li> Ensures proper handling of <code>PodArray::F32</code> type.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/ogawa-rs/pull/1/files#diff-0cc8085a56ce8eedfe5a01d719d9633874b5dbd79d1f458e940aa5388c089425">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>